### PR TITLE
Bump underscore from 1.12.1 to 1.13.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19558,9 +19558,10 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.19.8",
@@ -30731,7 +30732,7 @@
       "requires": {
         "esprima": "1.2.2",
         "static-eval": "2.0.2",
-        "underscore": "1.12.1"
+        "underscore": "1.13.8"
       },
       "dependencies": {
         "esprima": {
@@ -34583,9 +34584,9 @@
       }
     },
     "underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="
     },
     "undici-types": {
       "version": "6.19.8",

--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "tw-colors": "^3.3.2",
     "webpack": "^5.105.2"
   },
-  "homepage": "/ui-components/"
+  "homepage": "/ui-components/",
+  "overrides": {
+    "underscore": "1.13.8"
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes **Dependabot alert #50** — [CVE-2026-27601](https://github.com/jashkenas/underscore/security/advisories/GHSA-qpx9-hpmf-5gmw) (high severity)
- `underscore` <= 1.13.7 has unlimited recursion in `_.flatten` and `_.isEqual`, enabling DoS via stack overflow
- Added npm `overrides` in `package.json` to pin the transitive dependency (`react-scripts → bfj → jsonpath → underscore`) to **1.13.8**

## Impact
- No source files in the project directly use `underscore` — it is purely a transitive dependency
- Storybook build passes successfully with no new warnings
- Backward-compatible upgrade confirmed by underscore maintainers

## Test plan
- [x] Verified `npm ls underscore` shows 1.13.8 (overridden)
- [x] Verified `npm run build` (Storybook) passes
- [x] Searched codebase for direct underscore usage — none found
- [x] Reviewed changelog between 1.12.1 and 1.13.8 — no breaking API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)